### PR TITLE
Better handling for the city

### DIFF
--- a/lib/src/places_service.dart
+++ b/lib/src/places_service.dart
@@ -72,11 +72,17 @@ class PlacesService {
         // Indicate token reset on next auto complete request
         _resetSessionTokenForNextAutoComplete = true;
 
+        final locality =
+            _getShortNameFromComponent(detailsResponse.result, 'locality');
+        final subLocality =
+            _getShortNameFromComponent(detailsResponse.result, 'sublocality');
+
         PlaceDetails? details = detailsResponse.result;
         final streetNumber =
             _getShortNameFromComponent(details, 'street_number');
         final streetShort = _getShortNameFromComponent(details, 'route');
-        final city = _getShortNameFromComponent(details, 'locality');
+        // Sometimes, the Google Places API returns the city in 'sublocality' and leaves 'locality' empty.
+        final city = locality.isNotEmpty ? locality : subLocality;
         final state =
             _getShortNameFromComponent(details, 'administrative_area_level_1');
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: places_service
 description: A service that makes it easy to get information from the Places Api
-version: 0.1.4
+version: 0.1.5
 homepage: https://filledstacks.com
 
 environment:


### PR DESCRIPTION
Sometimes the `city` comes in `sublocality`, so added a basic check to ensure that.

More details can be found here
- https://developers.google.com/maps/documentation/places/web-service/supported_types
- https://stackoverflow.com/questions/32330117/retrieve-all-localities-and-sub-localities-from-given-city-google-places-api
